### PR TITLE
lksctp-tools: added version 1.0.21

### DIFF
--- a/var/spack/repos/builtin/packages/lksctp-tools/package.py
+++ b/var/spack/repos/builtin/packages/lksctp-tools/package.py
@@ -14,6 +14,7 @@ class LksctpTools(AutotoolsPackage):
 
     license("GPL-2.0-or-later AND LGPL-2.1-or-later")
 
+    version("1.0.21", sha256="8738bf17ecffbbe2440a6e2ffaf1cbcebb633fc99d63d88761af35c02a571893")
     version("1.0.18", sha256="3e9ab5b3844a8b65fc8152633aafe85f406e6da463e53921583dfc4a443ff03a")
 
     depends_on("c", type="build")  # generated


### PR DESCRIPTION
Adds version 1.0.21 of lksctp-tools

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
